### PR TITLE
Updated symfony/http-foundation dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         {
             "name": "Ivan Krutov",
             "email": "vania-pooh@yandex-team.ru",
-	        "role": "Developer"
+            "role": "Developer"
         }
     ],
     "support": {
@@ -16,12 +16,12 @@
         "source": "https://github.com/allure-framework/allure-php-api"
     },
     "require": {
-	    "php": ">=5.4.0",
+        "php": ">=5.4.0",
         "jms/serializer": ">=0.16.0",
         "rhumsaa/uuid": ">=2.7.0",
         "moontoast/math": ">=1.1.0",
         "phpunit/phpunit": ">=4.0.0",
-        "symfony/http-foundation": "~2.3.0"
+        "symfony/http-foundation": "~2.3"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Hi.
I've changed `symfony/http-foundation` dependency which now allows using any new `symfony/http-foundation` version up to (but not including) 3.0 - previous dependency was limited by 2.3.x version, so allure couldn't be used with modern projects using fresh `http-foundation` versions. Semantic versioning (major.minor.patch with no backwards-incompatible changes between major versions) is adopted as a standard in composer-based projects, and Symfony is a leading framework which doesn't break such rules, so it should be completely safe (Allure uses it only for mime-type guessing, and i guess this interface won't break even in 3.0).

Tests were ok with http-foundation v2.6.3.