### PR TITLE
Updating symfony/http-foundation to 2.6.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "rhumsaa/uuid": ">=2.7.0",
         "moontoast/math": ">=1.1.0",
         "phpunit/phpunit": ">=4.0.0",
-        "symfony/http-foundation": "~2.3"
+        "symfony/http-foundation": "2.6.*"
     },
     "autoload": {
         "psr-0": {

--- a/test/Yandex/Allure/Adapter/XMLValidationTest.php
+++ b/test/Yandex/Allure/Adapter/XMLValidationTest.php
@@ -92,7 +92,7 @@ class XMLValidationTest extends \PHPUnit_Framework_TestCase
         Allure::lifecycle()->fire($testCaseStartedEvent);
 
         $testCaseFailureEvent = new TestCaseFailedEvent();
-        $testCaseFailureEvent = $testCaseFailureEvent->withMessage(FAILURE_MESSAGE)->withException(new Exception());
+        $testCaseFailureEvent = $testCaseFailureEvent->withMessage(FAILURE_MESSAGE)->withException(new \Exception());
         Allure::lifecycle()->fire($testCaseFailureEvent);
 
         $stepStartedEvent = new StepStartedEvent(STEP_NAME);


### PR DESCRIPTION
Proposing to update Symfony http-foundation requirement for being able to use Allure with Laravel framework. 

The problem is that this requirement is colliding with the Laravel's required version which is `2.6.*`.

When I cloned the original repo, I've tried to run phpunit test. I get the fatal error.

`Fatal error: Class 'SebastianBergmann\Exporter\Exception' not found in /Users/burdiyan/Desktop/allure/test/Yandex/Allure/Adapter/XMLValidationTest.php on line 95`

I've tried to install sebastian/exporter and run tests again. Didn't help.

When I escaped `Exception` with `\Exception` in `test/Yandex/Allure/Adapter/XMLValidationTest.php
` line `95` I could run tests finally. I don't actually know if this is a bug or my problem.

When I updated Symfony to 2.6 tests also was running correctly.