### PR TITLE
Add method to get supported Severity levels

### DIFF
--- a/src/Yandex/Allure/Adapter/Model/SeverityLevel.php
+++ b/src/Yandex/Allure/Adapter/Model/SeverityLevel.php
@@ -13,4 +13,18 @@ final class SeverityLevel
     const NORMAL = 'normal';
     const MINOR = 'minor';
     const TRIVIAL = 'trivial';
+
+    /**
+     * @return array
+     */
+    public function getSupportedSeverityLevels()
+    {
+        return [
+            self::BLOCKER,
+            self::CRITICAL,
+            self::NORMAL,
+            self::MINOR,
+            self::TRIVIAL,
+        ];
+    }
 }


### PR DESCRIPTION
Since Allure CLI tool crashes horribly when encountered with `severity` label of onknown value, it would be nice to provide Downstream with method to get allowed severity levels to dynamically decide on whether provided severity is valid one or not (consider Cucumber/Gherkin scenarios, where tags can be used to mark severity).