### PR TITLE
Add Severity Label value validation

### DIFF
--- a/src/Yandex/Allure/Adapter/Model/Label.php
+++ b/src/Yandex/Allure/Adapter/Model/Label.php
@@ -30,6 +30,10 @@ class Label implements Entity
     public function __construct($name, $value)
     {
         $this->name = $name;
+
+        if ($name == LabelType::SEVERITY) {
+            ConstantChecker::validate('Yandex\Allure\Adapter\Model\SeverityLevel', $value);
+        }
         $this->value = $value;
     }
 


### PR DESCRIPTION
Since Allure CLI tool crashes horribly when encountered with severity label of onknown value, it's better to validate Label value and throw exception in case value is not supported.